### PR TITLE
[FearlessTobi] citra-qt : Fix a bug in our fullscreen implementation

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -721,14 +721,13 @@ void GMainWindow::OnStartGame() {
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
     connect(emu_thread.get(), SIGNAL(ErrorThrown(Core::System::ResultStatus, std::string)), this,
-        SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
+            SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
 
     ui.action_Start->setEnabled(false);
     ui.action_Start->setText(tr("Continue"));
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
-
 }
 
 void GMainWindow::OnPauseGame() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -721,7 +721,7 @@ void GMainWindow::OnStartGame() {
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
     connect(emu_thread.get(), SIGNAL(ErrorThrown(Core::System::ResultStatus, std::string)), this,
-    SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
+        SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
 
     ui.action_Start->setEnabled(false);
     ui.action_Start->setText(tr("Continue"));

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -571,7 +571,9 @@ void GMainWindow::BootGame(const QString& filename) {
     render_window->setFocus();
 
     emulation_running = true;
-    ToggleFullscreen();
+    if (ui.action_Fullscreen->isChecked()) {
+        ShowFullscreen();
+    }
     OnStartGame();
 }
 
@@ -719,13 +721,14 @@ void GMainWindow::OnStartGame() {
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
     connect(emu_thread.get(), SIGNAL(ErrorThrown(Core::System::ResultStatus, std::string)), this,
-            SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
+        SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
 
     ui.action_Start->setEnabled(false);
     ui.action_Start->setText(tr("Continue"));
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
+
 }
 
 void GMainWindow::OnPauseGame() {
@@ -745,21 +748,36 @@ void GMainWindow::ToggleFullscreen() {
         return;
     }
     if (ui.action_Fullscreen->isChecked()) {
-        if (ui.action_Single_Window_Mode->isChecked()) {
-            ui.menubar->hide();
-            statusBar()->hide();
-            showFullScreen();
-        } else {
-            render_window->showFullScreen();
-        }
-    } else {
-        if (ui.action_Single_Window_Mode->isChecked()) {
-            statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
-            ui.menubar->show();
-            showNormal();
-        } else {
-            render_window->showNormal();
-        }
+        ShowFullscreen();
+    }
+    else {
+        HideFullscreen();
+    }
+}
+
+void GMainWindow::ShowFullscreen() {
+    if (ui.action_Single_Window_Mode->isChecked()) {
+        UISettings::values.geometry = saveGeometry();
+        ui.menubar->hide();
+        statusBar()->hide();
+        showFullScreen();
+    }
+    else {
+        UISettings::values.renderwindow_geometry = render_window->saveGeometry();
+        render_window->showFullScreen();
+    }
+}
+
+void GMainWindow::HideFullscreen() {
+    if (ui.action_Single_Window_Mode->isChecked()) {
+        statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
+        ui.menubar->show();
+        showNormal();
+        restoreGeometry(UISettings::values.geometry);
+    }
+    else {
+        render_window->showNormal();
+        render_window->restoreGeometry(UISettings::values.renderwindow_geometry);
     }
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -748,8 +748,7 @@ void GMainWindow::ToggleFullscreen() {
     }
     if (ui.action_Fullscreen->isChecked()) {
         ShowFullscreen();
-    }
-    else {
+    } else {
         HideFullscreen();
     }
 }
@@ -760,8 +759,7 @@ void GMainWindow::ShowFullscreen() {
         ui.menubar->hide();
         statusBar()->hide();
         showFullScreen();
-    }
-    else {
+    } else {
         UISettings::values.renderwindow_geometry = render_window->saveGeometry();
         render_window->showFullScreen();
     }
@@ -773,8 +771,7 @@ void GMainWindow::HideFullscreen() {
         ui.menubar->show();
         showNormal();
         restoreGeometry(UISettings::values.geometry);
-    }
-    else {
+    } else {
         render_window->showNormal();
         render_window->restoreGeometry(UISettings::values.renderwindow_geometry);
     }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -721,14 +721,13 @@ void GMainWindow::OnStartGame() {
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
     connect(emu_thread.get(), SIGNAL(ErrorThrown(Core::System::ResultStatus, std::string)), this,
-        SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
+    SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
 
     ui.action_Start->setEnabled(false);
     ui.action_Start->setText(tr("Continue"));
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
-
 }
 
 void GMainWindow::OnPauseGame() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -721,13 +721,14 @@ void GMainWindow::OnStartGame() {
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
     connect(emu_thread.get(), SIGNAL(ErrorThrown(Core::System::ResultStatus, std::string)), this,
-    SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
+        SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
 
     ui.action_Start->setEnabled(false);
     ui.action_Start->setText(tr("Continue"));
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
+
 }
 
 void GMainWindow::OnPauseGame() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -721,7 +721,7 @@ void GMainWindow::OnStartGame() {
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
     connect(emu_thread.get(), SIGNAL(ErrorThrown(Core::System::ResultStatus, std::string)), this,
-        SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
+    SLOT(OnCoreError(Core::System::ResultStatus, std::string)));
 
     ui.action_Start->setEnabled(false);
     ui.action_Start->setText(tr("Continue"));

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -133,6 +133,8 @@ private slots:
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);
     void ToggleFullscreen();
+    void ShowFullscreen();
+    void HideFullscreen();
     void ToggleWindowMode();
     void OnCreateGraphicsSurfaceViewer();
     void OnCoreError(Core::System::ResultStatus, std::string);


### PR DESCRIPTION
Fixes the bug described [here](https://github.com/citra-emu/citra/pull/3001#issuecomment-338401048).
Therefore, the contents of ToggleFullscreen() have been refactored into ShowFullscreen() and HideFullscreen() (feel free to suggest better names for them) and tracking of the window geometry before it was fullscreen have been added.