### PR TITLE
Allow input configuration with SDL joysticks

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -71,9 +71,10 @@ ConfigureInput::ConfigureInput(QWidget* parent)
     for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
         if (button_map[button_id])
             connect(button_map[button_id], &QPushButton::released, [=]() {
-                handleClick(button_map[button_id],
-                            [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
-                            InputCommon::Polling::DeviceType::Button);
+                handleClick(
+                    button_map[button_id],
+                    [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
+                    InputCommon::Polling::DeviceType::Button);
             });
     }
 
@@ -95,9 +96,10 @@ ConfigureInput::ConfigureInput(QWidget* parent)
             QMessageBox::information(
                 this, "Information",
                 "After pressing OK, first move your joystick horizontally, and then vertically.");
-            handleClick(analog_map_stick[analog_id],
-                        [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },
-                        InputCommon::Polling::DeviceType::Analog);
+            handleClick(
+                analog_map_stick[analog_id],
+                [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },
+                InputCommon::Polling::DeviceType::Analog);
         });
     }
 

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -43,8 +43,7 @@ static void SetAnalogButton(const Common::ParamPackage& input_param,
 
 ConfigureInput::ConfigureInput(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()),
-      timeout_timer(std::make_unique<QTimer>()), poll_timer(std::make_unique<QTimer>()),
-      want_keyboard_keys(false) {
+      timeout_timer(std::make_unique<QTimer>()), poll_timer(std::make_unique<QTimer>()) {
 
     ui->setupUi(this);
     setFocusPolicy(Qt::ClickFocus);
@@ -207,11 +206,7 @@ void ConfigureInput::handleClick(QPushButton* button,
     device_pollers = InputCommon::Polling::GetPollers(type);
 
     // Keyboard keys can only be used as button devices
-    if (type == InputCommon::Polling::DeviceType::Button) {
-        want_keyboard_keys = true;
-    } else {
-        want_keyboard_keys = false;
-    }
+    want_keyboard_keys = type == InputCommon::Polling::DeviceType::Button;
 
     for (auto& poller : device_pollers) {
         poller->Start();

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -72,7 +72,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
         if (button_map[button_id])
             connect(button_map[button_id], &QPushButton::released, [=]() {
                 handleClick(button_map[button_id],
-                            [=](Common::ParamPackage params) { buttons_param[button_id] = params; },
+                            [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
                             InputCommon::Polling::DeviceType::Button);
             });
     }
@@ -83,7 +83,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                 connect(analog_map_buttons[analog_id][sub_button_id], &QPushButton::released,
                         [=]() {
                             handleClick(analog_map_buttons[analog_id][sub_button_id],
-                                        [=](Common::ParamPackage params) {
+                                        [=](const Common::ParamPackage& params) {
                                             SetAnalogButton(params, analogs_param[analog_id],
                                                             analog_sub_buttons[sub_button_id]);
                                         },
@@ -96,7 +96,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                 this, "Information",
                 "After pressing OK, first move your joystick horizontally, and then vertically.");
             handleClick(analog_map_stick[analog_id],
-                        [=](Common::ParamPackage params) { analogs_param[analog_id] = params; },
+                        [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },
                         InputCommon::Polling::DeviceType::Analog);
         });
     }
@@ -195,7 +195,7 @@ void ConfigureInput::updateButtonLabels() {
 }
 
 void ConfigureInput::handleClick(QPushButton* button,
-                                 std::function<void(Common::ParamPackage)> new_input_setter,
+                                 std::function<void(const Common::ParamPackage&)> new_input_setter,
                                  InputCommon::Polling::DeviceType type) {
     button->setText(tr("[press key]"));
     button->setFocus();

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -204,7 +204,7 @@ void ConfigureInput::handleClick(QPushButton* button,
 
     input_setter = new_input_setter;
 
-    device_pollers = InputCommon::Polling::getPollers(type);
+    device_pollers = InputCommon::Polling::GetPollers(type);
 
     // Keyboard keys can only be used as button devices
     if (type == InputCommon::Polling::DeviceType::Button) {

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -10,7 +10,6 @@
 #include "citra_qt/configuration/config.h"
 #include "citra_qt/configuration/configure_input.h"
 #include "common/param_package.h"
-#include "input_common/main.h"
 
 const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
     ConfigureInput::analog_sub_buttons{{

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -32,8 +32,8 @@ static QString getKeyName(int key_code) {
     }
 }
 
-static void SetAnalogButton(const Common::ParamPackage& input_param, Common::ParamPackage& analog_param,
-                         const std::string& button_name) {
+static void SetAnalogButton(const Common::ParamPackage& input_param,
+                            Common::ParamPackage& analog_param, const std::string& button_name) {
     if (analog_param.Get("engine", "") != "analog_from_button") {
         analog_param = {
             {"engine", "analog_from_button"}, {"modifier_scale", "0.5"},
@@ -219,7 +219,7 @@ void ConfigureInput::handleClick(QPushButton* button,
     grabKeyboard();
     grabMouse();
     timeout_timer->start(5000); // Cancel after 5 seconds
-    poll_timer->start(200); // Check for new inputs every 200ms
+    poll_timer->start(200);     // Check for new inputs every 200ms
 }
 
 void ConfigureInput::setPollingResult(const Common::ParamPackage& params, bool abort) {

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -66,7 +66,7 @@ private:
 
     /// A flag to indicate if keyboard keys are okay when configuring an input. If this is false,
     /// keyboard events are ignored.
-    bool want_keyboard_keys;
+    bool want_keyboard_keys = false;
 
     /// Load configuration settings.
     void loadConfiguration();

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -41,7 +41,7 @@ private:
     std::unique_ptr<QTimer> poll_timer;
 
     /// This will be the the setting function when an input is awaiting configuration.
-    boost::optional<std::function<void(Common::ParamPackage)>> input_setter;
+    boost::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
 
     std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
     std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;
@@ -77,7 +77,7 @@ private:
 
     /// Called when the button was pressed.
     void handleClick(QPushButton* button,
-                     std::function<void(Common::ParamPackage)> new_input_setter,
+                     std::function<void(const Common::ParamPackage&)> new_input_setter,
                      InputCommon::Polling::DeviceType type);
 
     /// Finish polling and configure input using the input_setter

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -43,7 +43,8 @@ public:
 private:
     std::unique_ptr<Ui::ConfigureInput> ui;
 
-    std::unique_ptr<QTimer> timer;
+    std::unique_ptr<QTimer> timeout_timer;
+    std::unique_ptr<QTimer> poll_timer;
 
     /// This will be the the setting function when an input is awaiting configuration.
     boost::optional<std::function<void(Common::ParamPackage)>> input_setter;
@@ -56,16 +57,22 @@ private:
     /// Each button input is represented by a QPushButton.
     std::array<QPushButton*, Settings::NativeButton::NumButtons> button_map;
 
-    /// Each analog input is represented by five QPushButtons which represents up, down, left, right
-    /// and modifier
+    /// A group of five QPushButtons represent one analog input. The buttons each represent up,
+    /// down, left, right, and modifier, respectively.
     std::array<std::array<QPushButton*, ANALOG_SUB_BUTTONS_NUM>, Settings::NativeAnalog::NumAnalogs>
         analog_map_buttons;
 
+    /// Analog inputs are also represented each with a single button, used to configure with an
+    /// actual analog stick
     std::array<QPushButton*, Settings::NativeAnalog::NumAnalogs> analog_map_stick;
 
     static const std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
 
     std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> device_pollers;
+
+    /// A flag to indicate if keyboard keys are okay when configuring an input. If this is false,
+    /// keyboard events are ignored.
+    bool want_keyboard_keys;
 
     /// Load configuration settings.
     void loadConfiguration();
@@ -78,6 +85,10 @@ private:
     void handleClick(QPushButton* button,
                      std::function<void(Common::ParamPackage)> new_input_setter,
                      InputCommon::Polling::DeviceType type);
+
+    /// Finish polling and configure input using the input_setter
+    void setPollingResult(const Common::ParamPackage& params, bool abort);
+
     /// Handle key press events.
     void keyPressEvent(QKeyEvent* event) override;
 };

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -14,6 +14,7 @@
 #include <boost/optional.hpp>
 #include "common/param_package.h"
 #include "core/settings.h"
+#include "input_common/main.h"
 #include "ui_configure_input.h"
 
 class QPushButton;
@@ -22,13 +23,6 @@ class QTimer;
 
 namespace Ui {
 class ConfigureInput;
-}
-
-namespace InputCommon {
-namespace Polling {
-class DevicePoller;
-enum class DeviceType;
-}
 }
 
 class ConfigureInput : public QWidget {

--- a/src/citra_qt/configuration/configure_input.ui
+++ b/src/citra_qt/configuration/configure_input.ui
@@ -289,6 +289,13 @@
         <bool>false</bool>
        </property>
        <layout class="QGridLayout" name="gridLayout_4">
+        <item row="2" column="0" colspan="2">
+         <widget class="QPushButton" name="buttonCircleAnalog">
+          <property name="text">
+           <string>Set Analog Stick</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="verticalLayout_17">
           <item>
@@ -447,6 +454,13 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item row="2" column="0" colspan="2">
+         <widget class="QPushButton" name="buttonCStickAnalog">
+          <property name="text">
+           <string>Set Analog Stick</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <memory>
-#include "common/param_package.h"
 #include "input_common/analog_from_button.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
@@ -71,4 +70,15 @@ std::string GenerateAnalogParamFromKeys(int key_up, int key_down, int key_left, 
     return circle_pad_param.Serialize();
 }
 
+namespace Polling {
+
+std::vector<std::unique_ptr<DevicePoller>> getPollers(DeviceType type) {
+#ifdef HAVE_SDL2
+    return SDL::Polling::getPollers(type);
+#else
+    return {};
+#endif
+}
+
+} // namespace Polling
 } // namespace InputCommon

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -72,9 +72,9 @@ std::string GenerateAnalogParamFromKeys(int key_up, int key_down, int key_left, 
 
 namespace Polling {
 
-std::vector<std::unique_ptr<DevicePoller>> getPollers(DeviceType type) {
+std::vector<std::unique_ptr<DevicePoller>> GetPollers(DeviceType type) {
 #ifdef HAVE_SDL2
-    return SDL::Polling::getPollers(type);
+    return SDL::Polling::GetPollers(type);
 #else
     return {};
 #endif

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include "common/param_package.h"
 #include "input_common/analog_from_button.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include "common/param_package.h"
 
 namespace InputCommon {

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -57,6 +57,6 @@ public:
 };
 
 // Get all DevicePoller from all backends for a specific device type
-std::vector<std::unique_ptr<DevicePoller>> getPollers(DeviceType type);
+std::vector<std::unique_ptr<DevicePoller>> GetPollers(DeviceType type);
 } // namespace Polling
 } // namespace InputCommon

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include "common/param_package.h"
 
 namespace InputCommon {
 
@@ -31,4 +32,30 @@ std::string GenerateKeyboardParam(int key_code);
 std::string GenerateAnalogParamFromKeys(int key_up, int key_down, int key_left, int key_right,
                                         int key_modifier, float modifier_scale);
 
+namespace Polling {
+
+enum class DeviceType { Button, Analog };
+
+/**
+ * A class that can be used to get inputs from an input device like controllers without having to
+ * poll the device's status yourself
+ */
+class DevicePoller {
+public:
+    virtual ~DevicePoller() = default;
+    /// Setup and start polling for inputs, should be called before GetNextInput
+    virtual void Start() = 0;
+    /// Stop polling
+    virtual void Stop() = 0;
+    /**
+     * Every call to this function returns the next input recorded since calling Start
+     * @return A ParamPackage of the recorded input, which can be used to create an InputDevice.
+     *         If there has been no input, the package is empty
+     */
+    virtual Common::ParamPackage GetNextInput() = 0;
+};
+
+// Get all DevicePoller from all backends for a specific device type
+std::vector<std::unique_ptr<DevicePoller>> getPollers(DeviceType type);
+} // namespace Polling
 } // namespace InputCommon

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -4,9 +4,13 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
-#include "common/param_package.h"
+
+namespace Common {
+class ParamPackage;
+}
 
 namespace InputCommon {
 

--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -10,6 +10,8 @@
 #include <SDL.h>
 #include "common/logging/log.h"
 #include "common/math_util.h"
+#include "common/param_package.h"
+#include "input_common/main.h"
 #include "input_common/sdl/sdl.h"
 
 namespace InputCommon {
@@ -306,7 +308,7 @@ public:
         // Empty event queue to get rid of old events. citra-qt doesn't use the queue
         SDL_Event dummy;
         while (SDL_PollEvent(&dummy)) {
-        };
+        }
     }
 
     void Stop() override {
@@ -342,7 +344,7 @@ public:
 
 class SDLAnalogPoller final : public SDLPoller {
 public:
-    SDLAnalogPoller() : analog_xaxis(-1), analog_yaxis(-1), analog_axes_joystick(-1) {}
+    SDLAnalogPoller() = default;
 
     ~SDLAnalogPoller() = default;
 
@@ -387,9 +389,9 @@ public:
     }
 
 private:
-    int analog_xaxis;
-    int analog_yaxis;
-    SDL_JoystickID analog_axes_joystick;
+    int analog_xaxis = -1;
+    int analog_yaxis = -1;
+    SDL_JoystickID analog_axes_joystick = -1;
 };
 
 std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(

--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <SDL.h>
 #include "common/logging/log.h"
 #include "common/math_util.h"
@@ -247,5 +248,158 @@ void Shutdown() {
     }
 }
 
+Common::ParamPackage SDLEventToButtonParamPackage(const SDL_Event& event) {
+    Common::ParamPackage params({{"engine", "sdl"}});
+    switch (event.type) {
+    case SDL_JOYAXISMOTION:
+        params.Set("joystick", event.jaxis.which);
+        params.Set("axis", event.jaxis.axis);
+        if (event.jaxis.value > 0) {
+            params.Set("direction", "+");
+            params.Set("threshold", "0.5");
+        } else {
+            params.Set("direction", "-");
+            params.Set("threshold", "-0.5");
+        }
+        break;
+    case SDL_JOYBUTTONUP:
+        params.Set("joystick", event.jbutton.which);
+        params.Set("button", event.jbutton.button);
+        break;
+    case SDL_JOYHATMOTION:
+        params.Set("joystick", event.jhat.which);
+        params.Set("hat", event.jhat.hat);
+        switch (event.jhat.value) {
+        case SDL_HAT_UP:
+            params.Set("direction", "up");
+            break;
+        case SDL_HAT_DOWN:
+            params.Set("direction", "down");
+            break;
+        case SDL_HAT_LEFT:
+            params.Set("direction", "left");
+            break;
+        case SDL_HAT_RIGHT:
+            params.Set("direction", "right");
+            break;
+        default:
+            return {};
+        }
+        break;
+    }
+    return params;
+}
+
+namespace Polling {
+
+class SDLPoller : public InputCommon::Polling::DevicePoller {
+public:
+    SDLPoller() = default;
+
+    ~SDLPoller() = default;
+
+    void Start() override {
+        // SDL joysticks must be opened, otherwise they don't generate events
+        int num_joysticks = SDL_NumJoysticks();
+        for (int i = 0; i < num_joysticks; i++) {
+            joysticks_opened.emplace_back(GetJoystick(i));
+        }
+        // Empty event queue to get rid of old events. citra-qt doesn't use the queue
+        SDL_Event dummy;
+        while (SDL_PollEvent(&dummy)) {
+        };
+    }
+
+    void Stop() override {
+        joysticks_opened.clear();
+    }
+
+private:
+    std::vector<std::shared_ptr<SDLJoystick>> joysticks_opened;
+};
+
+class SDLButtonPoller final : public SDLPoller {
+public:
+    SDLButtonPoller() = default;
+
+    ~SDLButtonPoller() = default;
+
+    Common::ParamPackage GetNextInput() override {
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            switch (event.type) {
+            case SDL_JOYAXISMOTION:
+            case SDL_JOYBUTTONUP:
+            case SDL_JOYHATMOTION:
+                return SDLEventToButtonParamPackage(event);
+            }
+        }
+        return {};
+    }
+};
+
+class SDLAnalogPoller final : public SDLPoller {
+public:
+    SDLAnalogPoller() : analog_axes(-1, -1), analog_axes_joystick(-1) {}
+
+    ~SDLAnalogPoller() = default;
+
+    void Start() override {
+        SDLPoller::Start();
+
+        // Reset stored axes
+        analog_axes = std::make_pair(-1, -1);
+        analog_axes_joystick = -1;
+    }
+
+    Common::ParamPackage GetNextInput() override {
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            if (event.type != SDL_JOYAXISMOTION) {
+                continue;
+            }
+            // An analog device needs two axes, so we need to store the axis for later and wait for
+            // a second SDL event. The axes also must be from the same joystick.
+            int axis = event.jaxis.axis;
+            if (analog_axes.first == -1) {
+                analog_axes.first = axis;
+                analog_axes_joystick = event.jaxis.which;
+            } else if (analog_axes.second == -1 && analog_axes.first != axis &&
+                       analog_axes_joystick == event.jaxis.which) {
+                analog_axes.second = axis;
+            }
+        }
+        Common::ParamPackage params;
+        if (analog_axes.first != -1 && analog_axes.second != -1) {
+            params.Set("engine", "sdl");
+            params.Set("joystick", analog_axes_joystick);
+            params.Set("axis_x", analog_axes.first);
+            params.Set("axis_y", analog_axes.second);
+            analog_axes = std::make_pair(-1, -1);
+            analog_axes_joystick = -1;
+            return params;
+        }
+        return params;
+    }
+
+private:
+    std::pair<int, int> analog_axes;
+    SDL_JoystickID analog_axes_joystick;
+};
+
+std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> getPollers(
+    InputCommon::Polling::DeviceType type) {
+    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> pollers;
+    switch (type) {
+    case InputCommon::Polling::DeviceType::Analog:
+        pollers.push_back(std::make_unique<SDLAnalogPoller>());
+        break;
+    case InputCommon::Polling::DeviceType::Button:
+        pollers.push_back(std::make_unique<SDLButtonPoller>());
+        break;
+    }
+    return std::move(pollers);
+}
+} // namespace Polling
 } // namespace SDL
 } // namespace InputCommon

--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -392,7 +392,7 @@ private:
     SDL_JoystickID analog_axes_joystick;
 };
 
-std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> getPollers(
+std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(
     InputCommon::Polling::DeviceType type) {
     std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> pollers;
     switch (type) {

--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
-#include <memory>
 #include <string>
 #include <tuple>
 #include <unordered_map>

--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -301,6 +301,7 @@ public:
 
     void Start() override {
         // SDL joysticks must be opened, otherwise they don't generate events
+        SDL_JoystickUpdate();
         int num_joysticks = SDL_NumJoysticks();
         for (int i = 0; i < num_joysticks; i++) {
             joysticks_opened.emplace_back(GetJoystick(i));

--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -27,7 +27,7 @@ Common::ParamPackage SDLEventToButtonParamPackage(const SDL_Event& event);
 namespace Polling {
 
 /// Get all DevicePoller that use the SDL backend for a specific device type
-std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> getPollers(
+std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(
     InputCommon::Polling::DeviceType type);
 
 } // namespace Polling

--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -6,11 +6,18 @@
 
 #include <memory>
 #include <vector>
-#include "common/param_package.h"
 #include "core/frontend/input.h"
-#include "input_common/main.h"
 
 union SDL_Event;
+namespace Common {
+class ParamPackage;
+}
+namespace InputCommon {
+namespace Polling {
+class DevicePoller;
+enum class DeviceType;
+} // namespace Polling
+} // namespace InputCommon
 
 namespace InputCommon {
 namespace SDL {

--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
 #include "common/param_package.h"
 #include "core/frontend/input.h"
 #include "input_common/main.h"

--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include "common/param_package.h"
 #include "core/frontend/input.h"
+#include "input_common/main.h"
+
+union SDL_Event;
 
 namespace InputCommon {
 namespace SDL {
@@ -15,5 +19,15 @@ void Init();
 /// Unresisters SDL device factories and shut them down.
 void Shutdown();
 
+/// Creates a ParamPackage from an SDL_Event that can directly be used to create a ButtonDevice
+Common::ParamPackage SDLEventToButtonParamPackage(const SDL_Event& event);
+
+namespace Polling {
+
+/// Get all DevicePoller that use the SDL backend for a specific device type
+std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> getPollers(
+    InputCommon::Polling::DeviceType type);
+
+} // namespace Polling
 } // namespace SDL
 } // namespace InputCommon


### PR DESCRIPTION
This PR adds the ability to configure controls using SDL gamepads (or joysticks, I guess). I created some scaffolding so that the settings dialog can ask for inputs from input backends. Basically, there is now an abstract DevicePoller class (if anyone has a better name, let me know) which can be implemented by different backends to return inputs.
There are a few ugly corners, which might or might not be a problem:

- The poller for SDL devices drops all SDL events it doesn't need. The Qt frontend doesn't use them, so it should be fine, but there might be other problems I'm not aware of.
- Configuring the analog sticks might be a bit confusing, because now you can configure them with 5 buttons, or an actual analog stick. Might need a better GUI for this.
- The buttons still have placeholder labels for SDL mappings, but that's easy to do once everything else is done.
There are two new buttons under the input tab in the configuration window to set analog stick controls (labeled "Set Analog Stick")
