### PR TITLE
Kernel/IPC: Add a small delay after each SyncRequest to prevent thread starvation.

### DIFF
--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -76,8 +76,10 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
             // starvation when a thread only does sync requests to HLE services while a
             // lower-priority thread is waiting to run.
 
-            // TODO(Subv): Figure out a good value for this.
-            static constexpr u64 IPCDelayNanoseconds = 100;
+            // This delay was approximated in a homebrew application by measuring the time it takes
+            // for a svcSendSyncRequest to return when performing an IPC request to a custom dummy
+            // service in an o3DS with firmware 11.6.
+            static constexpr u64 IPCDelayNanoseconds = 51140;
             thread->WakeAfterDelay(IPCDelayNanoseconds);
         } else {
             // Add the thread to the list of threads that have issued a sync request with this

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -62,13 +62,28 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
     // If this ServerSession has an associated HLE handler, forward the request to it.
     if (hle_handler != nullptr) {
         hle_handler->HandleSyncRequest(SharedPtr<ServerSession>(this));
-    } else {
+    }
+
+    if (thread->status == THREADSTATUS_RUNNING) {
         // Put the thread to sleep until the server replies, it will be awoken in
-        // svcReplyAndReceive.
+        // svcReplyAndReceive for LLE servers.
         thread->status = THREADSTATUS_WAIT_IPC;
-        // Add the thread to the list of threads that have issued a sync request with this
-        // server.
-        pending_requesting_threads.push_back(std::move(thread));
+
+        if (hle_handler != nullptr) {
+            // For HLE services, we put the request threads to sleep for a short duration to
+            // simulate IPC overhead, but only if the HLE handler didn't put the thread to sleep for
+            // other reasons like an async callback. The IPC overhead is needed to prevent
+            // starvation when a thread only does sync requests to HLE services while a
+            // lower-priority thread is waiting to run.
+
+            // TODO(Subv): Figure out a good value for this.
+            static constexpr u64 IPCDelayNanoseconds = 100;
+            thread->WakeAfterDelay(IPCDelayNanoseconds);
+        } else {
+            // Add the thread to the list of threads that have issued a sync request with this
+            // server.
+            pending_requesting_threads.push_back(std::move(thread));
+        }
     }
 
     // If this ServerSession does not have an HLE implementation, just wake up the threads waiting


### PR DESCRIPTION
(Sandbox)